### PR TITLE
fix: application hooks throws exception from instrumentation

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-fastify/src/constants.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/src/constants.ts
@@ -17,3 +17,10 @@
 export const spanRequestSymbol = Symbol(
   'opentelemetry.instrumentation.fastify.request_active_span'
 );
+
+export const applicationHookNames = [
+  'onRegister',
+  'onRoute',
+  'onReady',
+  'onClose',
+];

--- a/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
@@ -32,6 +32,7 @@ import type { HookHandlerDoneFunction } from 'fastify/types/hooks';
 import type { FastifyInstance } from 'fastify/types/instance';
 import type { FastifyReply } from 'fastify/types/reply';
 import type { FastifyRequest } from 'fastify/types/request';
+import { applicationHookNames } from './constants';
 import {
   AttributeNames,
   FastifyNames,
@@ -162,7 +163,7 @@ export class FastifyInstrumentation extends InstrumentationBase {
         const name = args[0] as string;
         const handler = args[1] as HandlerOriginal;
         const pluginName = this.pluginName;
-        if (name === 'onRegister') {
+        if (applicationHookNames.includes(name)) {
           return original.apply(this, [name as any, handler]);
         }
 


### PR DESCRIPTION
don't instrument application hooks, as they do not have the same structure as request hooks (req, reply, done) which cause instrumentation to throw and crash the application